### PR TITLE
Queue based processes

### DIFF
--- a/production/Handler.py
+++ b/production/Handler.py
@@ -39,10 +39,10 @@ class Handler(object):
             self.imageList = self.getDirectoryList(self.directoryName)
             print "Current list:", self.imageList
             time.sleep(constants.POLL_TIME)
-        print "Handler is exiting!"
-        print "Save the current image queue here!"
-        self.uploadOrders.get()
-        uploaderProcess.join()
+        print "Handler is exiting."
+        # Put actual cleanup/saving code here!
+        self.uploadOrders.get() #Tells the Uploader process to finish
+        uploaderProcess.join() #Waits for the Uploader process to finish
         print "Handler successfully exited."
     
     def enqueue(self, element=None):

--- a/production/Handler.py
+++ b/production/Handler.py
@@ -14,21 +14,23 @@ import os
 
 class Handler(object):
 
-    def __init__(self):
+    def __init__(self, orderQueue):
         config = Utility.getProjectConfig()
         # Extract relevant config data
         self.directoryName = config.get('directories', 'imagedirectory')
-        
+        self.orders = orderQueue
+        self.uploadOrders = Queue()
         self.queue = Queue()
         self.imageList = self.getDirectoryList(self.directoryName)
         
     def run(self):
         print "Hi, I'm a Handler!"
         print "Starting Uploader!"
+        self.uploadOrders.put("run")
         uploaderProcess = Process(target = self.startUploader)
         uploaderProcess.start()
         print self.directoryName
-        while True:
+        while not self.orders.empty():
             currentList = self.getDirectoryList(self.directoryName)
             listToUpload = self.getListDifference(self.imageList, currentList)
             if len(listToUpload) != 0:
@@ -37,7 +39,11 @@ class Handler(object):
             self.imageList = self.getDirectoryList(self.directoryName)
             print "Current list:", self.imageList
             time.sleep(constants.POLL_TIME)
+        print "Handler is exiting!"
+        print "Save the current image queue here!"
+        self.uploadOrders.get()
         uploaderProcess.join()
+        print "Handler successfully exited."
     
     def enqueue(self, element=None):
         if element is None:
@@ -45,7 +51,7 @@ class Handler(object):
         self.queue.put(element)
     
     def startUploader(self):
-        uploader = Uploader.Uploader(self.queue)
+        uploader = Uploader.Uploader(self.queue, self.uploadOrders)
         uploader.run()
 
     def getDirectoryList(self, path=None):

--- a/production/Reader.py
+++ b/production/Reader.py
@@ -11,18 +11,21 @@ import os
 
 class Reader(object):
 
-    def __init__(self):
+    def __init__(self, orders):
         config = Utility.getProjectConfig()
+        self.myOrders = orders
         # Extract relevant config data
         self.directoryName = config.get('directories', 'imagedirectory')
         os.chdir(self.directoryName)
     
     def run(self):
         print "Hi, I'm a Reader!"
-        while True:
+        while not self.myOrders.empty():
             time.sleep(constants.POLL_TIME)
             print "Reader, checking in! pid:", os.getpid()
             # Plug in actual functionality from prototypes!
-            
+        print "Reader is exiting."
+        
+        print "Reader successfully exited."
     
     

--- a/production/Reader.py
+++ b/production/Reader.py
@@ -25,7 +25,7 @@ class Reader(object):
             print "Reader, checking in! pid:", os.getpid()
             # Plug in actual functionality from prototypes!
         print "Reader is exiting."
-        
+        # Put actual cleanup/saving code here!
         print "Reader successfully exited."
     
     

--- a/production/Supervisor.py
+++ b/production/Supervisor.py
@@ -52,10 +52,10 @@ class Supervisor(object):
                     
                 elif job == "ContinuousUploadKill":
                     print "Killing Processes ... (they may still check in a few more times, this is normal)"
-                    self.handlerQueue.get() #Tells the Handler process to finish
-                    self.readerQueue.get() #Tells the Reader process to finish
-                    handlerProcess.join() #wait for the Handler process to finish
-                    readerProcess.join() #Wait the Reader process to finish
+                    self.handlerQueue.get() #Tells the Handler process to finish.
+                    self.readerQueue.get() #Tells the Reader process to finish.
+                    handlerProcess.join() #Wait for the Handler process to finish.
+                    readerProcess.join() #Wait the Reader process to finish.
                     print "Done killing processes."
                 elif job == "FileExplorer":
                     print "Supervisor handles FileExplorer job here if needed"

--- a/production/Supervisor.py
+++ b/production/Supervisor.py
@@ -51,11 +51,11 @@ class Supervisor(object):
                     readerProcess.start()
                     
                 elif job == "ContinuousUploadKill":
-                    print "Killing processeses... (they may still check in a few more times, this is normal)"
-                    self.handlerQueue.get()
-                    self.readerQueue.get()
-                    handlerProcess.join()
-                    readerProcess.join()
+                    print "Killing Processes ... (they may still check in a few more times, this is normal)"
+                    self.handlerQueue.get() #Tells the Handler process to finish
+                    self.readerQueue.get() #Tells the Reader process to finish
+                    handlerProcess.join() #wait for the Handler process to finish
+                    readerProcess.join() #Wait the Reader process to finish
                     print "Done killing processes."
                 elif job == "FileExplorer":
                     print "Supervisor handles FileExplorer job here if needed"
@@ -64,9 +64,8 @@ class Supervisor(object):
                 else:
                     raise Exception('Supervisor.run:  unexpected object in queue')
             time.sleep(constants.POLL_TIME)
-        #readerProcess.join()
-        #handlerProcess.join()
     
 if __name__ == '__main__':
     Supervisor().run()
     
+        

--- a/production/TouchScreenGUI.py
+++ b/production/TouchScreenGUI.py
@@ -31,38 +31,34 @@ class FrontEnd(object):
         topFrame.pack()
         
         #information for Upload Photos (continuous)
-        button1 = Button(topFrame, text="Upload Photos", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
-        button1.bind("<Button-1>", self.ContinuousUploadToggle)
+        self.button1 = Button(topFrame, text="Upload Photos: \nOFF", width=14, height=12, bg="orange", fg="white", font = "Verdana 12")
+        self.button1.bind("<Button-1>", self.ContinuousUploadToggle)
         
         #information for button2
-        button2 = Button(topFrame, text="File Explorer", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
-        button2.bind("<Button-1>", self.FileExplorer)
+        self.button2 = Button(topFrame, text="File Explorer", width=14, height=12, bg="orange", fg="white", font = "Verdana 12")
+        self.button2.bind("<Button-1>", self.FileExplorer)
         
         #information for button3
-        button3 = Button(topFrame, text="Settings", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
-        button3.bind("<Button-1>", self.Settings)
+        self.button3 = Button(topFrame, text="Settings", width=14, height=12, bg="orange", fg="white", font = "Verdana 12")
+        self.button3.bind("<Button-1>", self.Settings)
         
         #pack all information for the buttons 
-        button1.pack(side=LEFT)
-        button2.pack(side=LEFT)
-        button3.pack(side=LEFT)
+        self.button1.pack(side=LEFT)
+        self.button2.pack(side=LEFT)
+        self.button3.pack(side=LEFT)
         return root
 
     def ContinuousUploadToggle(self, event):
-         
         if self.toggle is False:
             print("Turning on photo upload...")    
-            #process = Process(target= self.startSupervisor)
-            #process.start()
             self.toggle = True
             self.queue.put("ContinuousUploadCreate")
-            #self.root = self.TkSetup()
-            #self.run()
-            # process.join()     
+            self.button1.config(text="Upload Photos: \nON")
         else: 
             print("Turning off photo upload...")
             self.toggle = False
             self.queue.put("ContinuousUploadKill")
+            self.button1.config(text="Upload Photos: \nOFF")
     
     def FileExplorer(self, event):
         print("Test for script to file explorer")

--- a/production/TouchScreenGUI.py
+++ b/production/TouchScreenGUI.py
@@ -1,0 +1,82 @@
+'''
+Created on Jan 25, 2016
+
+@author: stacypickens
+'''
+import os
+from Tkinter import *
+from multiprocessing import Process, Queue
+
+
+class FrontEnd(object):
+    
+    def __init__(self, sQueue):
+        self.toggle = False     # Variable for constant-upload mode 
+        self.root = self.TkSetup() 
+        self.queue = sQueue
+    
+    def run(self):
+        print "TouchScreenGUI, checking in! pid:", os.getpid()
+        self.root.mainloop()
+    
+    def TkSetup(self):
+        root = Tk()
+        root.wm_title("AU Photo Upload")
+        #img = PhotoImage(file='tiger.gif')
+        #root.tk.call('wm', 'iconphoto', root._w, img)
+        label = Label(root, text="AU Photo Upload", bg="orange", fg="white", font = "Verdana 15")
+        label.pack(fill=X)
+        
+        topFrame = Frame(root)
+        topFrame.pack()
+        
+        #information for Upload Photos (continuous)
+        button1 = Button(topFrame, text="Upload Photos", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
+        button1.bind("<Button-1>", self.ContinuousUploadToggle)
+        
+        #information for button2
+        button2 = Button(topFrame, text="File Explorer", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
+        button2.bind("<Button-1>", self.FileExplorer)
+        
+        #information for button3
+        button3 = Button(topFrame, text="Settings", width=12, height=12, bg="orange", fg="white", font = "Verdana 12")
+        button3.bind("<Button-1>", self.Settings)
+        
+        #pack all information for the buttons 
+        button1.pack(side=LEFT)
+        button2.pack(side=LEFT)
+        button3.pack(side=LEFT)
+        return root
+
+    def ContinuousUploadToggle(self, event):
+         
+        if self.toggle is False:
+            print("Turning on photo upload...")    
+            #process = Process(target= self.startSupervisor)
+            #process.start()
+            self.toggle = True
+            self.queue.put("ContinuousUploadCreate")
+            #self.root = self.TkSetup()
+            #self.run()
+            # process.join()     
+        else: 
+            print("Turning off photo upload...")
+            self.toggle = False
+            self.queue.put("ContinuousUploadKill")
+    
+    def FileExplorer(self, event):
+        print("Test for script to file explorer")
+        self.queue.put("FileExplorer")
+    
+    def Settings(self, event):
+        print("Test for script to settings")
+        self.queue.put("Settings")
+        
+    def startSupervisor(self):
+        svisor = Supervisor.Supervisor()
+        svisor.run()
+        
+if __name__ == '__main__':
+    blah = Queue()
+    FrontEnd().run(blah)
+  

--- a/production/Uploader.py
+++ b/production/Uploader.py
@@ -12,14 +12,14 @@ import dropbox
 
 class Uploader(object):
 
-    def __init__(self, q=None):
+    def __init__(self, q=None, orderQueue = None):
         if q is None:
             raise Exception('Uploader.__init__():  missing parameter')
         if not isinstance(q, multiprocessing.queues.Queue):
             raise Exception('Uploader.__init__():  parameter not of type ""')
-        
     
         self.queue = q
+        self.orders = orderQueue
         config = Utility.getProjectConfig()
         # Extract relevant config data
         inputKey = config.get("dropboxinfo", "key")
@@ -40,11 +40,14 @@ class Uploader(object):
     def run(self):
         print "Hi, I'm an Uploader!"
         time.sleep(1)
-        while True:
+        while not self.orders.empty():
             time.sleep(constants.POLL_TIME)
             print "Uploader, checking in! pid:", os.getpid()
             if not self.queue.empty():
                 self.uploadBatch()
+        print "Uploader is exiting."
+        #Do any cleanup here
+        print "Uploader successfully exited."
     
     def setApp(self, appKey = None, appSecret = None):
         self.myKey = appKey

--- a/production/Uploader.py
+++ b/production/Uploader.py
@@ -46,7 +46,7 @@ class Uploader(object):
             if not self.queue.empty():
                 self.uploadBatch()
         print "Uploader is exiting."
-        #Do any cleanup here
+        # Put actual cleanup/saving code here!
         print "Uploader successfully exited."
     
     def setApp(self, appKey = None, appSecret = None):


### PR DESCRIPTION
Under this scheme, parent processes pass a non-empty queue to child threads upon instantiation. This serves as a mechanism for the parent and child processes to pass messages in a thread-safe manner. Currently, functionality allows for parent classes to enqueue or dequeue an object to let child classes know that they should exit gracefully. TouchScreenGUI uses the queue passed to it by supervisor to let supervisor handle user inputs that require functionality outside it's own domain (like starting/ending photoUpload).
