### PR TITLE
Patrick - Timestamp renaming for newly detected file names

### DIFF
--- a/production/Handler.py
+++ b/production/Handler.py
@@ -36,10 +36,9 @@ class Handler(object):
             currentList = self.getDirectoryList(self.directoryName)
             listToUpload = self.getListDifference(self.imageList, currentList)
             if len(listToUpload) != 0:
-                #listToUpload = self.renameListWithTimestamps(listToUpload)
-                for element in listToUpload:
-                    
-                    self.enqueue(self.renameWithTimestamp(element))
+                for element in listToUpload:  
+                    self.enqueue(self.renameWithTimestamp(element)) # rename and submit the renamed image name
+                    #self.enqueue(element)
             self.imageList = self.getDirectoryList(self.directoryName)
             print "Current list:", self.imageList
             time.sleep(constants.POLL_TIME)
@@ -73,27 +72,28 @@ class Handler(object):
                 differenceList.append(element)
         return differenceList
     
-    def renameListWithTimestamps(self, oldList):
-        newList = []
-        for element in oldList:
-            newList.append(self.renameWithTimestamp(element))
-        return newList
-    
     def renameWithTimestamp(self, name):
+        time.sleep(1) # I HAVE NO CLUE WHY MY DUPLICATE CHECKING IS FAILING!!!
         i = str(datetime.datetime.now())
         # Convert '2016-02-08 11:16:04.123456 format to nicer filename
         timeStamp = i[0:10] + '-' + i[11:13] + '-' + i[14:16] + '-' + i[17:19]
+        ''' # Nonfunctional duplicate-checking code...
         renameFail = True
         counter = 0
         counterExtension = ''
         while renameFail:
-            try:
-                newName = (timeStamp + counterExtension + '.jpg')
-                subprocess.call(['mv', (self.directoryName + '/' + name), (self.directoryName + '/' + newName)])
+            newName = (timeStamp + counterExtension + '.jpg')
+            newPath = (self.directoryName + '/' + newName)
+            if not os.path.isfile(newPath):
+                subprocess.call(['mv', (self.directoryName + '/' + name), newPath])
                 renameFail = False
-            except OSError:
+            else:
                 counter += 1
                 counterExtension = str('-' + counter) 
+        '''
+        newName = (timeStamp + '.jpg')
+        newPath = (self.directoryName + '/' + newName)
+        subprocess.call(['mv', (self.directoryName + '/' + name), newPath])
         return newName
 
     

--- a/production/Handler.py
+++ b/production/Handler.py
@@ -11,6 +11,8 @@ import Uploader
 from multiprocessing import Process, Queue
 import time
 import os
+import datetime
+import subprocess
 
 class Handler(object):
 
@@ -34,8 +36,10 @@ class Handler(object):
             currentList = self.getDirectoryList(self.directoryName)
             listToUpload = self.getListDifference(self.imageList, currentList)
             if len(listToUpload) != 0:
+                #listToUpload = self.renameListWithTimestamps(listToUpload)
                 for element in listToUpload:
-                    self.enqueue(element)
+                    
+                    self.enqueue(self.renameWithTimestamp(element))
             self.imageList = self.getDirectoryList(self.directoryName)
             print "Current list:", self.imageList
             time.sleep(constants.POLL_TIME)
@@ -68,4 +72,28 @@ class Handler(object):
             if (element not in oldList): # verify correctness for strings!!!
                 differenceList.append(element)
         return differenceList
+    
+    def renameListWithTimestamps(self, oldList):
+        newList = []
+        for element in oldList:
+            newList.append(self.renameWithTimestamp(element))
+        return newList
+    
+    def renameWithTimestamp(self, name):
+        i = str(datetime.datetime.now())
+        # Convert '2016-02-08 11:16:04.123456 format to nicer filename
+        timeStamp = i[0:10] + '-' + i[11:13] + '-' + i[14:16] + '-' + i[17:19]
+        renameFail = True
+        counter = 0
+        counterExtension = ''
+        while renameFail:
+            try:
+                newName = (timeStamp + counterExtension + '.jpg')
+                subprocess.call(['mv', (self.directoryName + '/' + name), (self.directoryName + '/' + newName)])
+                renameFail = False
+            except OSError:
+                counter += 1
+                counterExtension = str('-' + counter) 
+        return newName
+
     

--- a/production/Supervisor.py
+++ b/production/Supervisor.py
@@ -46,7 +46,6 @@ class Supervisor(object):
             
         guiProcess = Process(target = self.startGUI)
         guiProcess.start()
-        self.guiQueue.put("ContinuousUploadCreate")     #TEMPORARY WORKAROUND FOR GUIPROCESS BUG
         handlerProcess = None
         readerProcess = None
         while True:

--- a/production/Supervisor.py
+++ b/production/Supervisor.py
@@ -6,12 +6,14 @@ Supervisor.py is the parent class and entry point for the PhotoUpload
     Direct child processes: Reader, Handler
 '''
 import PhotoUploadConstants as constants
+import PhotoUploadUtility as utility
 import Reader
 import Handler
 import os
 import time
 import TouchScreenGUI as tsgui
 from multiprocessing import Process, Queue
+import subprocess
 
 class Supervisor(object):
 
@@ -36,8 +38,15 @@ class Supervisor(object):
     
     def run(self):
         print "Supervisor, checking in! pid:", os.getpid()
+        # If image directory does not exist yet, create it!
+        config = utility.getProjectConfig()
+        imgdir = config.get('directories','imagedirectory')
+        if not os.path.isdir(imgdir):
+            subprocess.call(['mkdir', imgdir])  # os.mkdir might also work
+            
         guiProcess = Process(target = self.startGUI)
         guiProcess.start()
+        self.guiQueue.put("ContinuousUploadCreate")     #TEMPORARY WORKAROUND FOR GUIPROCESS BUG
         handlerProcess = None
         readerProcess = None
         while True:

--- a/production/TouchScreenGUI.py
+++ b/production/TouchScreenGUI.py
@@ -4,7 +4,6 @@ Created on Jan 25, 2016
 @author: stacypickens
 '''
 import os
-from Tkinter import *
 from multiprocessing import Process, Queue
 
 
@@ -20,6 +19,7 @@ class FrontEnd(object):
         self.root.mainloop()
     
     def TkSetup(self):
+        from Tkinter import *
         root = Tk()
         root.wm_title("AU Photo Upload")
         #img = PhotoImage(file='tiger.gif')
@@ -67,10 +67,6 @@ class FrontEnd(object):
     def Settings(self, event):
         print("Test for script to settings")
         self.queue.put("Settings")
-        
-    def startSupervisor(self):
-        svisor = Supervisor.Supervisor()
-        svisor.run()
         
 if __name__ == '__main__':
     blah = Queue()

--- a/production/photoUpload.cfg
+++ b/production/photoUpload.cfg
@@ -1,5 +1,5 @@
 [directories]
-imagedirectory = ../sandbox/testdirectory
+imagedirectory = _photo_upload_test_directory
 
 [dropboxinfo]
 key = kpwogxeclcczgmf


### PR DESCRIPTION
This patch to Handler updates the names of newly detected files with a timestamp. It also updates Supervisor to create the directory if it does not already exist. Also resolves the MacOS+Tkinter bug.

KNOWN PROBLEM: At the moment, the code 'freezes' for 1 second whenever a rename occurs. This is a temporary workaround for my faulty naming-conflict logic.
